### PR TITLE
feat: no-std adaptation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,9 @@ name = "petgraph"
 debug = true
 
 [dependencies]
-fixedbitset = { version = "0.4.0", default-features = false }
-indexmap = "2.0"
+fixedbitset = { version = "0.4", default-features = false }
+hashbrown = { version = "0.14", default-features = false, features = ["ahash"] }
+indexmap = { version = "2.0", default-features = false }
 quickcheck = { optional = true, version = "0.8", default-features = false }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
@@ -56,7 +57,8 @@ rayon = ["dep:rayon", "indexmap/rayon"]
 
 # feature flags for testing use only
 all = ["unstable", "quickcheck", "matrix_graph", "stable_graph", "graphmap", "rayon"]
-default = ["graphmap", "stable_graph", "matrix_graph"]
+default = ["std", "graphmap", "stable_graph", "matrix_graph"]
+std = []
 
 generate = [] # For unstable features
 

--- a/src/adj.rs
+++ b/src/adj.rs
@@ -4,9 +4,11 @@ use crate::iter_format::NoPretty;
 use crate::visit::{
     self, EdgeCount, EdgeRef, GetAdjacencyMatrix, IntoEdgeReferences, IntoNeighbors, NodeCount,
 };
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::fmt;
+use core::ops::Range;
 use fixedbitset::FixedBitSet;
-use std::fmt;
-use std::ops::Range;
 
 #[doc(no_inline)]
 pub use crate::graph::{DefaultIx, IndexType};
@@ -34,7 +36,7 @@ impl (Iterator) for
 #[derive(Debug, Clone)]
 struct OutgoingEdgeIndices <Ix> where { Ix: IndexType }
 item: EdgeIndex<Ix>,
-iter: std::iter::Map<std::iter::Zip<Range<usize>, std::iter::Repeat<NodeIndex<Ix>>>, fn((usize, NodeIndex<Ix>)) -> EdgeIndex<Ix>>,
+iter: core::iter::Map<core::iter::Zip<Range<usize>, core::iter::Repeat<NodeIndex<Ix>>>, fn((usize, NodeIndex<Ix>)) -> EdgeIndex<Ix>>,
 }
 
 /// Weighted sucessor
@@ -48,7 +50,7 @@ struct WSuc<E, Ix: IndexType> {
 
 /// One row of the adjacency list.
 type Row<E, Ix> = Vec<WSuc<E, Ix>>;
-type RowIter<'a, E, Ix> = std::slice::Iter<'a, WSuc<E, Ix>>;
+type RowIter<'a, E, Ix> = core::slice::Iter<'a, WSuc<E, Ix>>;
 
 iterator_wrap! {
 impl (Iterator DoubleEndedIterator ExactSizeIterator) for
@@ -56,7 +58,7 @@ impl (Iterator DoubleEndedIterator ExactSizeIterator) for
 #[derive(Debug, Clone)]
 struct Neighbors<'a, E, Ix> where { Ix: IndexType }
 item: NodeIndex<Ix>,
-iter: std::iter::Map<RowIter<'a, E, Ix>, fn(&WSuc<E, Ix>) -> NodeIndex<Ix>>,
+iter: core::iter::Map<RowIter<'a, E, Ix>, fn(&WSuc<E, Ix>) -> NodeIndex<Ix>>,
 }
 
 /// A reference to an edge of the graph.
@@ -98,7 +100,7 @@ impl<'a, E, Ix: IndexType> visit::EdgeRef for EdgeReference<'a, E, Ix> {
 
 #[derive(Debug, Clone)]
 pub struct EdgeIndices<'a, E, Ix: IndexType> {
-    rows: std::iter::Enumerate<std::slice::Iter<'a, Row<E, Ix>>>,
+    rows: core::iter::Enumerate<core::slice::Iter<'a, Row<E, Ix>>>,
     row_index: usize,
     row_len: usize,
     cur: usize,
@@ -135,7 +137,7 @@ iterator_wrap! {
     #[derive(Debug, Clone)]
     struct NodeIndices <Ix> where {}
     item: Ix,
-    iter: std::iter::Map<Range<usize>, fn(usize) -> Ix>,
+    iter: core::iter::Map<Range<usize>, fn(usize) -> Ix>,
 }
 
 /// An adjacency list with labeled edges.
@@ -269,7 +271,7 @@ impl<E, Ix: IndexType> List<E, Ix> {
                 successor_index,
             };
         let iter = (0..(self.suc[a.index()].len()))
-            .zip(std::iter::repeat(a))
+            .zip(core::iter::repeat(a))
             .map(proj);
         OutgoingEdgeIndices { iter }
     }
@@ -383,7 +385,7 @@ where
         let mut edge_list = f.debug_list();
         let iter: Self = self.clone();
         for e in iter {
-            if std::mem::size_of::<E>() != 0 {
+            if core::mem::size_of::<E>() != 0 {
                 edge_list.entry(&(
                     NoPretty((e.source().index(), e.target().index())),
                     e.weight(),
@@ -478,8 +480,8 @@ impl<'a, E, Ix: IndexType> IntoNeighbors for &'a List<E, Ix> {
     }
 }
 
-type SomeIter<'a, E, Ix> = std::iter::Map<
-    std::iter::Zip<std::iter::Enumerate<RowIter<'a, E, Ix>>, std::iter::Repeat<Ix>>,
+type SomeIter<'a, E, Ix> = core::iter::Map<
+    core::iter::Zip<core::iter::Enumerate<RowIter<'a, E, Ix>>, core::iter::Repeat<Ix>>,
     fn(((usize, &'a WSuc<E, Ix>), Ix)) -> EdgeReference<'a, E, Ix>,
 >;
 
@@ -488,9 +490,9 @@ impl (Iterator) for
 /// An iterator over the [`EdgeReference`] of all the edges of the graph.
 struct EdgeReferences<'a, E, Ix> where { Ix: IndexType }
 item: EdgeReference<'a, E, Ix>,
-iter: std::iter::FlatMap<
-    std::iter::Enumerate<
-        std::slice::Iter<'a, Row<E, Ix>>
+iter: core::iter::FlatMap<
+    core::iter::Enumerate<
+        core::slice::Iter<'a, Row<E, Ix>>
     >,
     SomeIter<'a, E, Ix>,
     fn(
@@ -519,7 +521,7 @@ fn proj1<E, Ix: IndexType>(
 fn proj2<E, Ix: IndexType>((row_index, row): (usize, &Vec<WSuc<E, Ix>>)) -> SomeIter<E, Ix> {
     row.iter()
         .enumerate()
-        .zip(std::iter::repeat(Ix::new(row_index)))
+        .zip(core::iter::repeat(Ix::new(row_index)))
         .map(proj1 as _)
 }
 
@@ -547,7 +549,7 @@ impl<'a, Ix: IndexType, E> visit::IntoEdges for &'a List<E, Ix> {
         let iter = self.suc[a.index()]
             .iter()
             .enumerate()
-            .zip(std::iter::repeat(a))
+            .zip(core::iter::repeat(a))
             .map(proj1 as _);
         OutgoingEdgeReferences { iter }
     }

--- a/src/algo/astar.rs
+++ b/src/algo/astar.rs
@@ -1,7 +1,10 @@
-use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::collections::{BinaryHeap, HashMap};
+use alloc::collections::BinaryHeap;
+use alloc::vec;
+use alloc::vec::Vec;
+use hashbrown::hash_map::Entry::{Occupied, Vacant};
+use hashbrown::HashMap;
 
-use std::hash::Hash;
+use core::hash::Hash;
 
 use crate::scored::MinScored;
 use crate::visit::{EdgeRef, GraphBase, IntoEdges, Visitable};

--- a/src/algo/bellman_ford.rs
+++ b/src/algo/bellman_ford.rs
@@ -1,6 +1,8 @@
 //! Bellman-Ford algorithms.
 
 use crate::prelude::*;
+use alloc::vec;
+use alloc::vec::Vec;
 
 use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeCount, NodeIndexable, VisitMap, Visitable};
 

--- a/src/algo/dijkstra.rs
+++ b/src/algo/dijkstra.rs
@@ -1,7 +1,8 @@
-use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::collections::{BinaryHeap, HashMap};
+use alloc::collections::BinaryHeap;
+use hashbrown::hash_map::Entry::{Occupied, Vacant};
+use hashbrown::HashMap;
 
-use std::hash::Hash;
+use core::hash::Hash;
 
 use crate::algo::Measure;
 use crate::scored::MinScored;
@@ -25,7 +26,7 @@ use crate::visit::{EdgeRef, IntoEdges, VisitMap, Visitable};
 /// use petgraph::Graph;
 /// use petgraph::algo::dijkstra;
 /// use petgraph::prelude::*;
-/// use std::collections::HashMap;
+/// use hashbrown::HashMap;
 ///
 /// let mut graph: Graph<(), (), Directed> = Graph::new();
 /// let a = graph.add_node(()); // node with no weight

--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -12,9 +12,11 @@
 //! strictly dominates **B** and there does not exist any node **C** where **A**
 //! dominates **C** and **C** dominates **B**.
 
-use std::cmp::Ordering;
-use std::collections::{hash_map::Iter, HashMap, HashSet};
-use std::hash::Hash;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::hash::Hash;
+use hashbrown::{hash_map::Iter, HashMap, HashSet};
 
 use crate::visit::{DfsPostOrder, GraphBase, IntoNeighbors, Visitable, Walker};
 
@@ -147,7 +149,7 @@ where
 
 /// The undefined dominator sentinel, for when we have not yet discovered a
 /// node's dominator.
-const UNDEFINED: usize = ::std::usize::MAX;
+const UNDEFINED: usize = core::usize::MAX;
 
 /// This is an implementation of the engineered ["Simple, Fast Dominance
 /// Algorithm"][0] discovered by Cooper et al.

--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -149,7 +149,7 @@ where
 
 /// The undefined dominator sentinel, for when we have not yet discovered a
 /// node's dominator.
-const UNDEFINED: usize = core::usize::MAX;
+const UNDEFINED: usize = usize::MAX;
 
 /// This is an implementation of the engineered ["Simple, Fast Dominance
 /// Algorithm"][0] discovered by Cooper et al.

--- a/src/algo/feedback_arc_set.rs
+++ b/src/algo/feedback_arc_set.rs
@@ -1,7 +1,7 @@
-use std::{
-    collections::{HashMap, VecDeque},
-    ops::{Index, IndexMut},
-};
+use alloc::collections::VecDeque;
+use alloc::vec::Vec;
+use core::ops::{Index, IndexMut};
+use hashbrown::HashMap;
 
 use crate::{
     graph::{GraphIndex, NodeIndex},
@@ -329,7 +329,8 @@ impl Buckets {
 }
 
 mod linked_list {
-    use std::{marker::PhantomData, ops::IndexMut};
+    use alloc::vec::Vec;
+    use core::{marker::PhantomData, ops::IndexMut};
 
     #[derive(PartialEq, Debug)]
     pub struct LinkedList<Data, Container, Ix> {

--- a/src/algo/floyd_warshall.rs
+++ b/src/algo/floyd_warshall.rs
@@ -1,6 +1,7 @@
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
-use std::hash::Hash;
+use alloc::vec;
+use core::hash::Hash;
 
 use crate::algo::{BoundedMeasure, NegativeCycle};
 use crate::visit::{

--- a/src/algo/floyd_warshall.rs
+++ b/src/algo/floyd_warshall.rs
@@ -55,7 +55,7 @@ use crate::visit::{
 /// //    |      v         v
 /// //     --->  d <-------
 ///
-/// let inf = std::i32::MAX;
+/// let inf = i32::MAX;
 /// let expected_res: HashMap<(NodeIndex, NodeIndex), i32> = [
 ///    ((a, a), 0), ((a, b), 1), ((a, c), 3), ((a, d), 3),
 ///    ((b, a), inf), ((b, b), 0), ((b, c), 2), ((b, d), 2),

--- a/src/algo/isomorphism.rs
+++ b/src/algo/isomorphism.rs
@@ -52,7 +52,7 @@ mod state {
             let c0 = g.node_count();
             Vf2State {
                 graph: g,
-                mapping: vec![core::usize::MAX; c0],
+                mapping: vec![usize::MAX; c0],
                 out: vec![0; c0],
                 ins: vec![0; c0 * (g.is_directed() as usize)],
                 out_size: 0,
@@ -93,7 +93,7 @@ mod state {
         /// Restore the state to before the last added mapping
         pub fn pop_mapping(&mut self, from: G::NodeId) {
             // undo (n, m) mapping
-            self.mapping[self.graph.to_index(from)] = core::usize::MAX;
+            self.mapping[self.graph.to_index(from)] = usize::MAX;
 
             // unmark in ins and outs
             for ix in self.graph.neighbors_directed(from, Outgoing) {
@@ -120,7 +120,7 @@ mod state {
                 .iter()
                 .enumerate()
                 .find(move |&(index, &elt)| {
-                    elt > 0 && self.mapping[from_index + index] == core::usize::MAX
+                    elt > 0 && self.mapping[from_index + index] == usize::MAX
                 })
                 .map(|(index, _)| index)
         }
@@ -134,7 +134,7 @@ mod state {
                 .iter()
                 .enumerate()
                 .find(move |&(index, &elt)| {
-                    elt > 0 && self.mapping[from_index + index] == core::usize::MAX
+                    elt > 0 && self.mapping[from_index + index] == usize::MAX
                 })
                 .map(|(index, _)| index)
         }
@@ -144,7 +144,7 @@ mod state {
             self.mapping[from_index..]
                 .iter()
                 .enumerate()
-                .find(|&(_, &elt)| elt == core::usize::MAX)
+                .find(|&(_, &elt)| elt == usize::MAX)
                 .map(|(index, _)| index)
         }
     }
@@ -322,7 +322,7 @@ mod matching {
                     } else {
                         field!(st, 1 - $j).graph.to_index(field!(nodes, 1 - $j))
                     };
-                    if m_neigh == core::usize::MAX {
+                    if m_neigh == usize::MAX {
                         continue;
                     }
                     let has_edge = field!(st, 1 - $j).graph.is_adjacent(
@@ -348,7 +348,7 @@ mod matching {
                     pred_count += 1;
                     // the self loop case is handled in outgoing
                     let m_neigh = field!(st, $j).mapping[field!(st, $j).graph.to_index(n_neigh)];
-                    if m_neigh == core::usize::MAX {
+                    if m_neigh == usize::MAX {
                         continue;
                     }
                     let has_edge = field!(st, 1 - $j).graph.is_adjacent(
@@ -406,7 +406,7 @@ mod matching {
                         } else {
                             field!(st, 1 - $j).graph.to_index(field!(nodes, 1 - $j))
                         };
-                        if m_neigh == core::usize::MAX {
+                        if m_neigh == usize::MAX {
                             continue;
                         }
 
@@ -433,7 +433,7 @@ mod matching {
                             // the self loop case is handled in outgoing
                             let m_neigh =
                                 field!(st, $j).mapping[field!(st, $j).graph.to_index(n_neigh)];
-                            if m_neigh == core::usize::MAX {
+                            if m_neigh == usize::MAX {
                                 continue;
                             }
 

--- a/src/algo/isomorphism.rs
+++ b/src/algo/isomorphism.rs
@@ -1,4 +1,6 @@
-use std::convert::TryFrom;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 
 use crate::data::DataMap;
 use crate::visit::EdgeCount;
@@ -50,7 +52,7 @@ mod state {
             let c0 = g.node_count();
             Vf2State {
                 graph: g,
-                mapping: vec![std::usize::MAX; c0],
+                mapping: vec![core::usize::MAX; c0],
                 out: vec![0; c0],
                 ins: vec![0; c0 * (g.is_directed() as usize)],
                 out_size: 0,
@@ -91,7 +93,7 @@ mod state {
         /// Restore the state to before the last added mapping
         pub fn pop_mapping(&mut self, from: G::NodeId) {
             // undo (n, m) mapping
-            self.mapping[self.graph.to_index(from)] = std::usize::MAX;
+            self.mapping[self.graph.to_index(from)] = core::usize::MAX;
 
             // unmark in ins and outs
             for ix in self.graph.neighbors_directed(from, Outgoing) {
@@ -118,7 +120,7 @@ mod state {
                 .iter()
                 .enumerate()
                 .find(move |&(index, &elt)| {
-                    elt > 0 && self.mapping[from_index + index] == std::usize::MAX
+                    elt > 0 && self.mapping[from_index + index] == core::usize::MAX
                 })
                 .map(|(index, _)| index)
         }
@@ -132,7 +134,7 @@ mod state {
                 .iter()
                 .enumerate()
                 .find(move |&(index, &elt)| {
-                    elt > 0 && self.mapping[from_index + index] == std::usize::MAX
+                    elt > 0 && self.mapping[from_index + index] == core::usize::MAX
                 })
                 .map(|(index, _)| index)
         }
@@ -142,7 +144,7 @@ mod state {
             self.mapping[from_index..]
                 .iter()
                 .enumerate()
-                .find(|&(_, &elt)| elt == std::usize::MAX)
+                .find(|&(_, &elt)| elt == core::usize::MAX)
                 .map(|(index, _)| index)
         }
     }
@@ -320,7 +322,7 @@ mod matching {
                     } else {
                         field!(st, 1 - $j).graph.to_index(field!(nodes, 1 - $j))
                     };
-                    if m_neigh == std::usize::MAX {
+                    if m_neigh == core::usize::MAX {
                         continue;
                     }
                     let has_edge = field!(st, 1 - $j).graph.is_adjacent(
@@ -346,7 +348,7 @@ mod matching {
                     pred_count += 1;
                     // the self loop case is handled in outgoing
                     let m_neigh = field!(st, $j).mapping[field!(st, $j).graph.to_index(n_neigh)];
-                    if m_neigh == std::usize::MAX {
+                    if m_neigh == core::usize::MAX {
                         continue;
                     }
                     let has_edge = field!(st, 1 - $j).graph.is_adjacent(
@@ -404,7 +406,7 @@ mod matching {
                         } else {
                             field!(st, 1 - $j).graph.to_index(field!(nodes, 1 - $j))
                         };
-                        if m_neigh == std::usize::MAX {
+                        if m_neigh == core::usize::MAX {
                             continue;
                         }
 
@@ -431,7 +433,7 @@ mod matching {
                             // the self loop case is handled in outgoing
                             let m_neigh =
                                 field!(st, $j).mapping[field!(st, $j).graph.to_index(n_neigh)];
-                            if m_neigh == std::usize::MAX {
+                            if m_neigh == core::usize::MAX {
                                 continue;
                             }
 

--- a/src/algo/k_shortest_path.rs
+++ b/src/algo/k_shortest_path.rs
@@ -1,6 +1,9 @@
-use std::collections::{BinaryHeap, HashMap};
+use alloc::collections::BinaryHeap;
+use alloc::vec;
+use alloc::vec::Vec;
+use hashbrown::HashMap;
 
-use std::hash::Hash;
+use core::hash::Hash;
 
 use crate::algo::Measure;
 use crate::scored::MinScored;
@@ -26,7 +29,7 @@ use crate::visit::{EdgeRef, IntoEdges, NodeCount, NodeIndexable, Visitable};
 /// use petgraph::Graph;
 /// use petgraph::algo::k_shortest_path;
 /// use petgraph::prelude::*;
-/// use std::collections::HashMap;
+/// use hashbrown::HashMap;
 ///
 /// let mut graph : Graph<(),(),Directed>= Graph::new();
 /// let a = graph.add_node(()); // node with no weight

--- a/src/algo/matching.rs
+++ b/src/algo/matching.rs
@@ -1,5 +1,7 @@
-use std::collections::VecDeque;
-use std::hash::Hash;
+use alloc::collections::VecDeque;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::hash::Hash;
 
 use crate::visit::{
     EdgeRef, GraphBase, IntoEdges, IntoNeighbors, IntoNodeIdentifiers, NodeCount, NodeIndexable,
@@ -372,7 +374,7 @@ where
     // The dummy identifier needs an unused index
     assert_ne!(
         graph.node_bound(),
-        std::usize::MAX,
+        core::usize::MAX,
         "The input graph capacity should be strictly less than std::usize::MAX."
     );
 
@@ -387,7 +389,7 @@ where
     debug_assert_eq!(mate.len(), len);
 
     let mut label: Vec<Label<G>> = vec![Label::None; len];
-    let mut first_inner = vec![std::usize::MAX; len];
+    let mut first_inner = vec![core::usize::MAX; len];
     let visited = &mut graph.visit_map();
 
     for start in 0..graph.node_bound() {
@@ -526,7 +528,7 @@ fn find_join<G, F>(
     let join = loop {
         // Swap the sides. Do not swap if the right side is already finished.
         if right != graph.dummy_idx() {
-            std::mem::swap(&mut left, &mut right);
+            core::mem::swap(&mut left, &mut right);
         }
 
         // Set left to the next inner vertex in P(source) or P(target).

--- a/src/algo/matching.rs
+++ b/src/algo/matching.rs
@@ -334,7 +334,7 @@ impl<G: GraphBase> PartialEq for Label<G> {
 /// *O(|V|³)*. An algorithm with a better time complexity might be used in the
 /// future.
 ///
-/// **Panics** if `g.node_bound()` is `std::usize::MAX`.
+/// **Panics** if `g.node_bound()` is `usize::MAX`.
 ///
 /// # Examples
 ///
@@ -374,8 +374,8 @@ where
     // The dummy identifier needs an unused index
     assert_ne!(
         graph.node_bound(),
-        core::usize::MAX,
-        "The input graph capacity should be strictly less than std::usize::MAX."
+        usize::MAX,
+        "The input graph capacity should be strictly less than usize::MAX."
     );
 
     // Greedy algorithm should create a fairly good initial matching. The hope
@@ -389,7 +389,7 @@ where
     debug_assert_eq!(mate.len(), len);
 
     let mut label: Vec<Label<G>> = vec![Label::None; len];
-    let mut first_inner = vec![core::usize::MAX; len];
+    let mut first_inner = vec![usize::MAX; len];
     let visited = &mut graph.visit_map();
 
     for start in 0..graph.node_bound() {

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -16,8 +16,11 @@ pub mod matching;
 pub mod simple_paths;
 pub mod tred;
 
-use std::collections::{BinaryHeap, HashMap};
-use std::num::NonZeroUsize;
+use alloc::collections::BinaryHeap;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::num::NonZeroUsize;
+use hashbrown::HashMap;
 
 use crate::prelude::*;
 
@@ -366,8 +369,8 @@ impl<N> TarjanScc<N> {
     /// Creates a new `TarjanScc`
     pub fn new() -> Self {
         TarjanScc {
-            index: 1,                        // Invariant: index < componentcount at all times.
-            componentcount: std::usize::MAX, // Will hold if componentcount is initialized to number of nodes - 1 or higher.
+            index: 1,                         // Invariant: index < componentcount at all times.
+            componentcount: core::usize::MAX, // Will hold if componentcount is initialized to number of nodes - 1 or higher.
             nodes: Vec::new(),
             stack: Vec::new(),
         }
@@ -486,7 +489,7 @@ impl<N> TarjanScc<N> {
             rindex > self.componentcount,
             "Given node has been visited but not yet assigned to a component."
         );
-        std::usize::MAX - rindex
+        core::usize::MAX - rindex
     }
 }
 
@@ -767,14 +770,14 @@ pub struct NegativeCycle(pub ());
 pub fn is_bipartite_undirected<G, N, VM>(g: G, start: N) -> bool
 where
     G: GraphRef + Visitable<NodeId = N, Map = VM> + IntoNeighbors<NodeId = N>,
-    N: Copy + PartialEq + std::fmt::Debug,
+    N: Copy + PartialEq + core::fmt::Debug,
     VM: VisitMap<N>,
 {
     let mut red = g.visit_map();
     red.visit(start);
     let mut blue = g.visit_map();
 
-    let mut stack = ::std::collections::VecDeque::new();
+    let mut stack = alloc::collections::VecDeque::new();
     stack.push_front(start);
 
     while let Some(node) = stack.pop_front() {
@@ -814,8 +817,8 @@ where
     true
 }
 
-use std::fmt::Debug;
-use std::ops::Add;
+use core::fmt::Debug;
+use core::ops::Add;
 
 /// Associated data that can be used for measures (such as length).
 pub trait Measure: Debug + PartialOrd + Add<Self, Output = Self> + Default + Clone {}
@@ -846,7 +849,7 @@ impl FloatMeasure for f64 {
     }
 }
 
-pub trait BoundedMeasure: Measure + std::ops::Sub<Self, Output = Self> {
+pub trait BoundedMeasure: Measure + core::ops::Sub<Self, Output = Self> {
     fn min() -> Self;
     fn max() -> Self;
     fn overflowing_add(self, rhs: Self) -> (Self, bool);
@@ -857,11 +860,11 @@ macro_rules! impl_bounded_measure_integer(
         $(
             impl BoundedMeasure for $t {
                 fn min() -> Self {
-                    std::$t::MIN
+                    core::$t::MIN
                 }
 
                 fn max() -> Self {
-                    std::$t::MAX
+                    core::$t::MAX
                 }
 
                 fn overflowing_add(self, rhs: Self) -> (Self, bool) {
@@ -879,19 +882,19 @@ macro_rules! impl_bounded_measure_float(
         $(
             impl BoundedMeasure for $t {
                 fn min() -> Self {
-                    std::$t::MIN
+                    core::$t::MIN
                 }
 
                 fn max() -> Self {
-                    std::$t::MAX
+                    core::$t::MAX
                 }
 
                 fn overflowing_add(self, rhs: Self) -> (Self, bool) {
                     // for an overflow: a + b > max: both values need to be positive and a > max - b must be satisfied
-                    let overflow = self > Self::default() && rhs > Self::default() && self > std::$t::MAX - rhs;
+                    let overflow = self > Self::default() && rhs > Self::default() && self > core::$t::MAX - rhs;
 
                     // for an underflow: a + b < min: overflow can not happen and both values must be negative and a < min - b must be satisfied
-                    let underflow = !overflow && self < Self::default() && rhs < Self::default() && self < std::$t::MIN - rhs;
+                    let underflow = !overflow && self < Self::default() && rhs < Self::default() && self < core::$t::MIN - rhs;
 
                     (self + rhs, overflow || underflow)
                 }

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -369,8 +369,8 @@ impl<N> TarjanScc<N> {
     /// Creates a new `TarjanScc`
     pub fn new() -> Self {
         TarjanScc {
-            index: 1,                         // Invariant: index < componentcount at all times.
-            componentcount: core::usize::MAX, // Will hold if componentcount is initialized to number of nodes - 1 or higher.
+            index: 1,                   // Invariant: index < componentcount at all times.
+            componentcount: usize::MAX, // Will hold if componentcount is initialized to number of nodes - 1 or higher.
             nodes: Vec::new(),
             stack: Vec::new(),
         }
@@ -489,7 +489,7 @@ impl<N> TarjanScc<N> {
             rindex > self.componentcount,
             "Given node has been visited but not yet assigned to a component."
         );
-        core::usize::MAX - rindex
+        usize::MAX - rindex
     }
 }
 
@@ -860,11 +860,11 @@ macro_rules! impl_bounded_measure_integer(
         $(
             impl BoundedMeasure for $t {
                 fn min() -> Self {
-                    core::$t::MIN
+                    $t::MIN
                 }
 
                 fn max() -> Self {
-                    core::$t::MAX
+                    $t::MAX
                 }
 
                 fn overflowing_add(self, rhs: Self) -> (Self, bool) {
@@ -882,19 +882,19 @@ macro_rules! impl_bounded_measure_float(
         $(
             impl BoundedMeasure for $t {
                 fn min() -> Self {
-                    core::$t::MIN
+                    $t::MIN
                 }
 
                 fn max() -> Self {
-                    core::$t::MAX
+                    $t::MAX
                 }
 
                 fn overflowing_add(self, rhs: Self) -> (Self, bool) {
                     // for an overflow: a + b > max: both values need to be positive and a > max - b must be satisfied
-                    let overflow = self > Self::default() && rhs > Self::default() && self > core::$t::MAX - rhs;
+                    let overflow = self > Self::default() && rhs > Self::default() && self > $t::MAX - rhs;
 
                     // for an underflow: a + b < min: overflow can not happen and both values must be negative and a < min - b must be satisfied
-                    let underflow = !overflow && self < Self::default() && rhs < Self::default() && self < core::$t::MIN - rhs;
+                    let underflow = !overflow && self < Self::default() && rhs < Self::default() && self < $t::MIN - rhs;
 
                     (self + rhs, overflow || underflow)
                 }

--- a/src/algo/simple_paths.rs
+++ b/src/algo/simple_paths.rs
@@ -1,8 +1,10 @@
-use std::{
+use alloc::vec;
+use core::{
     hash::Hash,
     iter::{from_fn, FromIterator},
 };
 
+use hashbrown::hash_map::DefaultHashBuilder;
 use indexmap::IndexSet;
 
 use crate::{
@@ -58,7 +60,7 @@ where
     let min_length = min_intermediate_nodes + 1;
 
     // list of visited nodes
-    let mut visited: IndexSet<G::NodeId> = IndexSet::from_iter(Some(from));
+    let mut visited: IndexSet<G::NodeId, DefaultHashBuilder> = IndexSet::from_iter(Some(from));
     // list of childs of currently exploring path nodes,
     // last elem is list of childs of last visited node
     let mut stack = vec![graph.neighbors_directed(from, Outgoing)];
@@ -103,7 +105,8 @@ where
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashSet, iter::FromIterator};
+    use core::iter::FromIterator;
+    use hashbrown::HashSet;
 
     use itertools::assert_equal;
 

--- a/src/algo/tred.rs
+++ b/src/algo/tred.rs
@@ -14,6 +14,8 @@ use crate::visit::{
     GraphBase, IntoNeighbors, IntoNeighborsDirected, NodeCompactIndexable, NodeCount,
 };
 use crate::Direction;
+use alloc::vec;
+use alloc::vec::Vec;
 use fixedbitset::FixedBitSet;
 
 /// Creates a representation of the same graph respecting topological order for use in `tred::dag_transitive_reduction_closure`.

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -1,10 +1,12 @@
 //! Compressed Sparse Row (CSR) is a sparse adjacency matrix graph.
 
-use std::cmp::{max, Ordering};
-use std::iter::{Enumerate, Zip};
-use std::marker::PhantomData;
-use std::ops::{Index, IndexMut, Range};
-use std::slice::Windows;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cmp::{max, Ordering};
+use core::iter::{Enumerate, Zip};
+use core::marker::PhantomData;
+use core::ops::{Index, IndexMut, Range};
+use core::slice::Windows;
 
 use crate::visit::{
     Data, EdgeCount, EdgeRef, GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences,
@@ -130,6 +132,7 @@ where
 
 /// Csr creation error: edges were not in sorted order.
 #[derive(Clone, Debug)]
+#[allow(dead_code)]
 pub struct EdgesNotSorted {
     first_error: (usize, usize),
 }
@@ -586,7 +589,7 @@ where
     }
 }
 
-use std::slice::Iter as SliceIter;
+use core::slice::Iter as SliceIter;
 
 #[derive(Clone, Debug)]
 pub struct Neighbors<'a, Ix: 'a = DefaultIx> {

--- a/src/data.rs
+++ b/src/data.rs
@@ -8,6 +8,7 @@ use crate::stable_graph::StableGraph;
 use crate::visit::{Data, NodeCount, NodeIndexable, Reversed};
 use crate::EdgeType;
 use crate::Graph;
+use alloc::vec::Vec;
 
 trait_template! {
     /// Access node and edge weights (associated data).

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -1,6 +1,7 @@
 //! Simple graphviz dot file format output.
 
-use std::fmt::{self, Display, Write};
+use alloc::string::String;
+use core::fmt::{self, Display, Write};
 
 use crate::visit::{
     EdgeRef, GraphProp, IntoEdgeReferences, IntoNodeReferences, NodeIndexable, NodeRef,
@@ -281,7 +282,8 @@ mod test {
     use super::{Config, Dot, Escaper};
     use crate::prelude::Graph;
     use crate::visit::NodeRef;
-    use std::fmt::Write;
+    use alloc::string::String;
+    use core::fmt::Write;
 
     #[test]
     fn test_escape() {

--- a/src/graph_impl/frozen.rs
+++ b/src/graph_impl/frozen.rs
@@ -1,4 +1,4 @@
-use std::ops::{Deref, Index, IndexMut};
+use core::ops::{Deref, Index, IndexMut};
 
 use super::Frozen;
 use crate::data::{DataMap, DataMapMut};

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -1,11 +1,13 @@
-use std::cmp;
-use std::fmt;
-use std::hash::Hash;
-use std::iter;
-use std::marker::PhantomData;
-use std::mem::size_of;
-use std::ops::{Index, IndexMut, Range};
-use std::slice;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cmp;
+use core::fmt;
+use core::hash::Hash;
+use core::iter;
+use core::marker::PhantomData;
+use core::mem::size_of;
+use core::ops::{Index, IndexMut, Range};
+use core::slice;
 
 use fixedbitset::FixedBitSet;
 
@@ -48,7 +50,7 @@ unsafe impl IndexType for usize {
     }
     #[inline(always)]
     fn max() -> Self {
-        ::std::usize::MAX
+        core::usize::MAX
     }
 }
 
@@ -63,7 +65,7 @@ unsafe impl IndexType for u32 {
     }
     #[inline(always)]
     fn max() -> Self {
-        ::std::u32::MAX
+        core::u32::MAX
     }
 }
 
@@ -78,7 +80,7 @@ unsafe impl IndexType for u16 {
     }
     #[inline(always)]
     fn max() -> Self {
-        ::std::u16::MAX
+        core::u16::MAX
     }
 }
 
@@ -93,7 +95,7 @@ unsafe impl IndexType for u8 {
     }
     #[inline(always)]
     fn max() -> Self {
-        ::std::u8::MAX
+        core::u8::MAX
     }
 }
 
@@ -431,7 +433,7 @@ enum Pair<T> {
     None,
 }
 
-use std::cmp::max;
+use core::cmp::max;
 
 /// Get mutable references at index `a` and `b`.
 fn index_twice<T>(slc: &mut [T], a: usize, b: usize) -> Pair<&mut T> {
@@ -1770,7 +1772,7 @@ where
 
 /// Iterator yielding immutable access to all node weights.
 pub struct NodeWeights<'a, N: 'a, Ix: IndexType = DefaultIx> {
-    nodes: ::std::slice::Iter<'a, Node<N, Ix>>,
+    nodes: core::slice::Iter<'a, Node<N, Ix>>,
 }
 impl<'a, N, Ix> Iterator for NodeWeights<'a, N, Ix>
 where
@@ -1789,7 +1791,7 @@ where
 /// Iterator yielding mutable access to all node weights.
 #[derive(Debug)]
 pub struct NodeWeightsMut<'a, N: 'a, Ix: IndexType = DefaultIx> {
-    nodes: ::std::slice::IterMut<'a, Node<N, Ix>>, // TODO: change type to something that implements Clone?
+    nodes: core::slice::IterMut<'a, Node<N, Ix>>, // TODO: change type to something that implements Clone?
 }
 
 impl<'a, N, Ix> Iterator for NodeWeightsMut<'a, N, Ix>
@@ -1809,7 +1811,7 @@ where
 
 /// Iterator yielding immutable access to all edge weights.
 pub struct EdgeWeights<'a, E: 'a, Ix: IndexType = DefaultIx> {
-    edges: ::std::slice::Iter<'a, Edge<E, Ix>>,
+    edges: core::slice::Iter<'a, Edge<E, Ix>>,
 }
 
 impl<'a, E, Ix> Iterator for EdgeWeights<'a, E, Ix>
@@ -1830,7 +1832,7 @@ where
 /// Iterator yielding mutable access to all edge weights.
 #[derive(Debug)]
 pub struct EdgeWeightsMut<'a, E: 'a, Ix: IndexType = DefaultIx> {
-    edges: ::std::slice::IterMut<'a, Edge<E, Ix>>, // TODO: change type to something that implements Clone?
+    edges: core::slice::IterMut<'a, Edge<E, Ix>>, // TODO: change type to something that implements Clone?
 }
 
 impl<'a, E, Ix> Iterator for EdgeWeightsMut<'a, E, Ix>

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -50,7 +50,7 @@ unsafe impl IndexType for usize {
     }
     #[inline(always)]
     fn max() -> Self {
-        core::usize::MAX
+        usize::MAX
     }
 }
 
@@ -65,7 +65,7 @@ unsafe impl IndexType for u32 {
     }
     #[inline(always)]
     fn max() -> Self {
-        core::u32::MAX
+        u32::MAX
     }
 }
 
@@ -80,7 +80,7 @@ unsafe impl IndexType for u16 {
     }
     #[inline(always)]
     fn max() -> Self {
-        core::u16::MAX
+        u16::MAX
     }
 }
 
@@ -95,7 +95,7 @@ unsafe impl IndexType for u8 {
     }
     #[inline(always)]
     fn max() -> Self {
-        core::u8::MAX
+        u8::MAX
     }
 }
 

--- a/src/graph_impl/serialization.rs
+++ b/src/graph_impl/serialization.rs
@@ -1,6 +1,7 @@
 use serde::de::Error;
 
-use std::marker::PhantomData;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
 
 use crate::prelude::*;
 

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -3,18 +3,19 @@
 //! Depends on `feature = "stable_graph"`.
 //!
 
-use std::cmp;
-use std::fmt;
-use std::iter;
-use std::marker::PhantomData;
-use std::mem::replace;
-use std::mem::size_of;
-use std::ops::{Index, IndexMut};
-use std::slice;
+use core::cmp;
+use core::fmt;
+use core::iter;
+use core::marker::PhantomData;
+use core::mem::replace;
+use core::mem::size_of;
+use core::ops::{Index, IndexMut};
+use core::slice;
 
 use fixedbitset::FixedBitSet;
 
 use crate::{Directed, Direction, EdgeType, Graph, Incoming, Outgoing, Undirected};
+use alloc::vec;
 
 use crate::iter_format::{DebugMap, IterFormatExt, NoPretty};
 use crate::iter_utils::IterUtilsExt;

--- a/src/graph_impl/stable_graph/serialization.rs
+++ b/src/graph_impl/stable_graph/serialization.rs
@@ -1,7 +1,8 @@
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use std::marker::PhantomData;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
 
 use crate::prelude::*;
 

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -1,19 +1,21 @@
 //! `GraphMap<N, E, Ty>` is a graph datastructure where node values are mapping
 //! keys.
 
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::fmt;
+use core::hash::{self, Hash};
+use core::iter::FromIterator;
+use core::iter::{Cloned, DoubleEndedIterator};
+use core::marker::PhantomData;
+use core::mem;
+use core::ops::{Deref, Index, IndexMut};
+use core::slice::Iter;
+use hashbrown::hash_map::DefaultHashBuilder;
+use hashbrown::HashSet;
 use indexmap::map::Keys;
 use indexmap::map::{Iter as IndexMapIter, IterMut as IndexMapIterMut};
 use indexmap::IndexMap;
-use std::cmp::Ordering;
-use std::collections::HashSet;
-use std::fmt;
-use std::hash::{self, Hash};
-use std::iter::FromIterator;
-use std::iter::{Cloned, DoubleEndedIterator};
-use std::marker::PhantomData;
-use std::mem;
-use std::ops::{Deref, Index, IndexMut};
-use std::slice::Iter;
 
 use crate::{Directed, Direction, EdgeType, Incoming, Outgoing, Undirected};
 
@@ -64,8 +66,8 @@ pub type DiGraphMap<N, E> = GraphMap<N, E, Directed>;
 /// Depends on crate feature `graphmap` (default).
 #[derive(Clone)]
 pub struct GraphMap<N, E, Ty> {
-    nodes: IndexMap<N, Vec<(N, CompactDirection)>>,
-    edges: IndexMap<(N, N), E>,
+    nodes: IndexMap<N, Vec<(N, CompactDirection)>, DefaultHashBuilder>,
+    edges: IndexMap<(N, N), E, DefaultHashBuilder>,
     ty: PhantomData<Ty>,
 }
 
@@ -179,8 +181,8 @@ where
     /// Create a new `GraphMap` with estimated capacity.
     pub fn with_capacity(nodes: usize, edges: usize) -> Self {
         GraphMap {
-            nodes: IndexMap::with_capacity(nodes),
-            edges: IndexMap::with_capacity(edges),
+            nodes: IndexMap::with_capacity_and_hasher(nodes, DefaultHashBuilder::default()),
+            edges: IndexMap::with_capacity_and_hasher(edges, DefaultHashBuilder::default()),
             ty: PhantomData,
         }
     }
@@ -708,7 +710,7 @@ where
     Ty: EdgeType,
 {
     from: N,
-    edges: &'a IndexMap<(N, N), E>,
+    edges: &'a IndexMap<(N, N), E, DefaultHashBuilder>,
     iter: Neighbors<'a, N, Ty>,
 }
 
@@ -741,7 +743,7 @@ where
 {
     from: N,
     dir: Direction,
-    edges: &'a IndexMap<(N, N), E>,
+    edges: &'a IndexMap<(N, N), E, DefaultHashBuilder>,
     iter: NeighborsDirected<'a, N, Ty>,
 }
 

--- a/src/iter_format.rs
+++ b/src/iter_format.rs
@@ -1,7 +1,7 @@
 //! Formatting utils
 
-use std::cell::RefCell;
-use std::fmt;
+use core::cell::RefCell;
+use core::fmt;
 
 /// Format the iterator like a map
 pub struct DebugMap<F>(pub F);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,8 @@
 //!   Defaults on. Enables [`MatrixGraph`](./matrix_graph/struct.MatrixGraph.html).
 //!
 #![doc(html_root_url = "https://docs.rs/petgraph/0.4/")]
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 
 extern crate fixedbitset;
 #[cfg(feature = "graphmap")]

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -1,10 +1,13 @@
 //! `MatrixGraph<N, E, Ty, NullN, NullE, Ix>` is a graph datastructure backed by an adjacency matrix.
 
-use std::marker::PhantomData;
-use std::ops::{Index, IndexMut};
+use core::marker::PhantomData;
+use core::ops::{Index, IndexMut};
 
-use std::cmp;
-use std::mem;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cmp;
+use core::mem;
+use hashbrown::hash_map::DefaultHashBuilder;
 
 use indexmap::IndexSet;
 
@@ -904,7 +907,7 @@ fn ensure_len<T: Default>(v: &mut Vec<T>, size: usize) {
 struct IdStorage<T> {
     elements: Vec<Option<T>>,
     upper_bound: usize,
-    removed_ids: IndexSet<usize>,
+    removed_ids: IndexSet<usize, DefaultHashBuilder>,
 }
 
 impl<T> IdStorage<T> {
@@ -912,7 +915,7 @@ impl<T> IdStorage<T> {
         IdStorage {
             elements: Vec::with_capacity(capacity),
             upper_bound: 0,
-            removed_ids: IndexSet::new(),
+            removed_ids: IndexSet::with_hasher(DefaultHashBuilder::default()),
         }
     }
 
@@ -979,7 +982,7 @@ impl<T> IndexMut<usize> for IdStorage<T> {
 #[derive(Debug, Clone)]
 struct IdIterator<'a> {
     upper_bound: usize,
-    removed_ids: &'a IndexSet<usize>,
+    removed_ids: &'a IndexSet<usize, DefaultHashBuilder>,
     current: Option<usize>,
 }
 

--- a/src/quickcheck.rs
+++ b/src/quickcheck.rs
@@ -5,6 +5,8 @@ use crate::graph::{node_index, IndexType};
 #[cfg(feature = "stable_graph")]
 use crate::stable_graph::StableGraph;
 use crate::{EdgeType, Graph};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 #[cfg(feature = "graphmap")]
 use crate::graphmap::{GraphMap, NodeTrait};

--- a/src/scored.rs
+++ b/src/scored.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 /// `MinScored<K, T>` holds a score `K` and a scored object `T` in
 /// a pair for use with a `BinaryHeap`.

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -1,7 +1,8 @@
+use alloc::vec::Vec;
+use core::fmt;
+use core::marker::PhantomData;
 use serde::de::{Deserialize, Error, SeqAccess, Visitor};
 use serde::ser::{Serialize, SerializeSeq, Serializer};
-use std::fmt;
-use std::marker::PhantomData;
 
 /// Map to serializeable representation
 pub trait IntoSerializable {

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -1,7 +1,9 @@
 //! `UnionFind<K>` is a disjoint-set data structure.
 
 use super::graph::IndexType;
-use std::cmp::Ordering;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
 
 /// `UnionFind<K>` is a disjoint-set data structure. It tracks set membership of *n* elements
 /// indexed from *0* to *n - 1*. The scalar type is `K` which must be an unsigned integer type.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use std::iter;
+use core::iter;
 
 pub fn enumerate<I>(iterable: I) -> iter::Enumerate<I::IntoIter>
 where

--- a/src/visit/filter.rs
+++ b/src/visit/filter.rs
@@ -1,8 +1,8 @@
 use crate::prelude::*;
 
+use core::marker::PhantomData;
 use fixedbitset::FixedBitSet;
-use std::collections::HashSet;
-use std::marker::PhantomData;
+use hashbrown::HashSet;
 
 use crate::data::DataMap;
 use crate::visit::{Data, NodeCompactIndexable, NodeCount};

--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -73,9 +73,9 @@ mod traversal;
 pub use self::dfsvisit::*;
 pub use self::traversal::*;
 
+use core::hash::{BuildHasher, Hash};
 use fixedbitset::FixedBitSet;
-use std::collections::HashSet;
-use std::hash::{BuildHasher, Hash};
+use hashbrown::HashSet;
 
 use super::EdgeType;
 use crate::prelude::Direction;

--- a/src/visit/traversal.rs
+++ b/src/visit/traversal.rs
@@ -1,7 +1,8 @@
 use super::{GraphRef, IntoNodeIdentifiers, Reversed};
 use super::{IntoNeighbors, IntoNeighborsDirected, VisitMap, Visitable};
 use crate::Incoming;
-use std::collections::VecDeque;
+use alloc::collections::VecDeque;
+use alloc::vec::Vec;
 
 /// Visit nodes of a graph in a depth-first-search (DFS) emitting nodes in
 /// preorder (when they are first discovered).

--- a/tests/floyd_warshall.rs
+++ b/tests/floyd_warshall.rs
@@ -30,7 +30,7 @@ fn floyd_warshall_uniform_weight() {
     // |       v       |       v
     // d <---- c       h <---- g
 
-    let inf = std::i32::MAX;
+    let inf = i32::MAX;
     let expected_res: HashMap<(NodeIndex, NodeIndex), i32> = [
         ((a, a), 0),
         ((a, b), 1),
@@ -123,7 +123,7 @@ fn floyd_warshall_weighted() {
 
     graph.extend_with_edges(&[(a, b), (a, c), (a, d), (b, c), (b, d), (c, d)]);
 
-    let inf = std::i32::MAX;
+    let inf = i32::MAX;
     let expected_res: HashMap<(NodeIndex, NodeIndex), i32> = [
         ((a, a), 0),
         ((a, b), 1),
@@ -191,7 +191,7 @@ fn floyd_warshall_weighted_undirected() {
 
     graph.extend_with_edges(&[(a, b), (a, c), (a, d), (b, d), (c, b), (c, d)]);
 
-    let inf = std::i32::MAX;
+    let inf = i32::MAX;
     let expected_res: HashMap<(NodeIndex, NodeIndex), i32> = [
         ((a, a), 0),
         ((a, b), 1),
@@ -258,7 +258,7 @@ fn floyd_warshall_negative_cycle() {
 
     graph.extend_with_edges(&[(a, b), (b, c), (c, a)]);
 
-    let inf = std::i32::MAX;
+    let inf = i32::MAX;
 
     let weight_map: HashMap<(NodeIndex, NodeIndex), i32> = [
         ((a, a), 0),

--- a/tests/k_shortest_path.rs
+++ b/tests/k_shortest_path.rs
@@ -1,7 +1,7 @@
+use hashbrown::HashMap;
 use petgraph::algo::k_shortest_path;
 use petgraph::prelude::*;
 use petgraph::Graph;
-use std::collections::HashMap;
 
 #[test]
 fn second_shortest_path() {


### PR DESCRIPTION
Besides no-std adaptation, another mini improvement commit is included:
```
chore: update depricated MAX constant

Using `std::` or `core::` is deprecated with `MAX`.
Use `usize::MAX` instead.
```
